### PR TITLE
add killproof.me plugin

### DIFF
--- a/arcdps_killproof.me/update-placeholder.yaml
+++ b/arcdps_killproof.me/update-placeholder.yaml
@@ -1,0 +1,38 @@
+# Update files are intended to provide information for:
+# Installation
+# Plugin configuration
+# User-Facing information displayed on the addon manager UI
+
+### USER-FACING INFO ###
+# developer of the add-on
+developer: knoxfighter
+# website where more information about the add-on can be found
+website: https://github.com/knoxfighter/arcdps-killproof.me-plugin
+# name of the add-on
+addon_name: ArcDPS Killproof-me Plugin
+# descriptive text for the addon
+description: This addon shows the killproofs of players, that are registered on killproof.me
+# tooltip - basically description but in brief
+tooltip: Shows killproof.me data ingame
+
+### DOWNLOADING/INSTALLATION ###
+# github or standalone
+host_type: github
+# either github API url or direct URL to file/archive - former is parsed to find latest version and download link,
+# latter is a direct download link to a file/archive
+host_url: https://api.github.com/repos/knoxfighter/arcdps-killproof.me-plugin/releases/latest
+# for md5sum files and things of that nature; files that exist solely to show what the latest version is. Standalone only.
+version_url:
+# archive or .dll
+download_type: .dll
+# binary or d3d9 - binary leaves plugin name as-is, d3d9 means filename may be changed for chainloading
+install_mode: arc
+#
+plugin_name: d3d9_arcdps_killproof_me.dll
+
+### CONFIGURATION ###
+# a list of all other add-ons required for this add-on to function
+requires:
+    - arcdps
+# a list of all add-ons that prevent this add-on from functioning properly
+conflicts:


### PR DESCRIPTION
I wrote a plugin, that is loading killproof.me data into the game and showing it ingame. The dll is automatically compatible with arcdps d3d9.dll direct loading, as well as with the renamed `gw2addon_arcdps.dll` file from the addon loader.