### PR TITLE
[fixed] Add my arcdps addon to approved list

### DIFF
--- a/arcdps_know_thy-enemy/update-placeholder.yaml
+++ b/arcdps_know_thy-enemy/update-placeholder.yaml
@@ -1,0 +1,38 @@
+# Update files are intended to provide information for:
+# Installation
+# Plugin configuration
+# User-Facing information displayed on the addon manager UI
+
+### USER-FACING INFO ###
+# developer of the add-on
+developer: typedeck0
+# website where more information about the add-on can be found
+website: https://github.com/typedeck0/Know-thy-enemy
+# name of the add-on
+addon_name: "ArcDPS [WvW] Know thy enemy"
+# descriptive text for the addon
+description: "A WvW addon that counts the amount and type of player enemies (that your squad hits or is hit by) in an arcdps fight instance (resets when arcdps does)."
+# tooltip - basically description but in brief
+tooltip: Counts the amount and type of player enemies in a fight
+
+### DOWNLOADING/INSTALLATION ###
+# github or standalone
+host_type: github
+# either github API url or direct URL to file/archive - former is parsed to find latest version and download link,
+# latter is a direct download link to a file/archive
+host_url: https://api.github.com/repos/typedeck0/Know-thy-enemy/releases/latest
+# for md5sum files and things of that nature; files that exist solely to show what the latest version is. Standalone only.
+version_url:
+# archive or .dll
+download_type: .dll
+# binary or d3d9 - binary leaves plugin name as-is, d3d9 means filename may be changed for chainloading
+install_mode: arc
+#
+plugin_name: know-thy-enemy.dll
+
+### CONFIGURATION ###
+# a list of all other add-ons required for this add-on to function
+requires:
+    - arcdps
+# a list of all add-ons that prevent this add-on from functioning properly
+conflicts:


### PR DESCRIPTION
I was using the the website url as the host url instead of the api url, fixed now.